### PR TITLE
Reuse allocation of ks_asm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keystone-engine"
-version = "0.1.0"
-author = ["lyte <maxime.peterlin@impalabs.fr>"]
+version = "0.2.0"
+authors = ["lyte <maxime.peterlin@impalabs.fr>"]
 edition = "2021"
 description = "Rust bindings for the Keystone Engine assembler library."
 documentation = "https://docs.rs/keystone-engine"


### PR DESCRIPTION
Basically this:
```diff
-    pub fn asm(&self, insns: String, address: u64) -> Result<KeystoneOutput> {
+    pub fn asm(&self, insns: &CStr, address: u64) -> Result<KeystoneOutput> {
// and
 pub struct KeystoneOutput {
-    /// Size of the array storing the encoded instructions.
-    pub size: u32,
     /// Number of instructions that were successfully encoded.
-    pub stat_count: u32,
-    /// Array of encoded instructions.
-    pub bytes: Vec<u8>,
+    pub stat_count: size_t,
+    /// Size of the array storing the encoded instructions.
+    size: size_t,
+    /// A pointer of allocated encoded instructions.
+    ptr: *mut u8,
+}
+impl Drop for KeystoneOutput {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::ks_free(self.ptr);
+        }
+    }
+}
```

From https://github.com/keystone-engine/keystone/pull/589 but it stalled